### PR TITLE
auth/url fixes

### DIFF
--- a/care/sms/api.py
+++ b/care/sms/api.py
@@ -31,8 +31,10 @@ class QualtricsFormUpdateWebhookAPIView(generics.CreateAPIView):
 
     def create(self, request, *args, **kwargs):
         # hopefully this is enough for authentication.
-        if not request.data['auth_token'] == settings.WEBHOOK_TOKEN:
-            return Response(status=status.HTTP_403_FORBIDDEN)
+        auth_enabled = getattr(settings, 'WEBHOOK_AUTH_ENABLE', None)
+        if auth_enabled is not None:
+            if auth_enabled and not request.data['auth_token'] == settings.WEBHOOK_TOKEN:
+                return Response(status=status.HTTP_403_FORBIDDEN)
         az_now = pytz.timezone('America/Phoenix').localize(pytz.datetime.datetime.now())
         # uuid is embedded data in the qualtrics survey
         uuid = request.data.get('uuid', None)

--- a/care/urls.py
+++ b/care/urls.py
@@ -17,7 +17,7 @@ from care.frontend import views as front_views
 urlpatterns = [
     path('', front_views.index),
     path('admin/', admin.site.urls),
-    path('api/qualtrics/webhook', QualtricsFormUpdateWebhookAPIView.as_view()),
+    path('api/qualtrics/webhook/', QualtricsFormUpdateWebhookAPIView.as_view()),
     path('api/twilio/conversations', TwilioConversationCallbackAPIView.as_view()),
     path('api/conversations', TwilioConversationListAPIView.as_view()),
     path('api/conversations/reply', TwilioConversationReplyAPIView.as_view()),


### PR DESCRIPTION
make auth on the webhook API toggleable via setting (WEBHOOK_AUTH_ENABLE = True/False)
 change API URL to have trailing slash since that's what Qualtrics is expecting apparently.