### PR TITLE
fix liaison weekly email command

### DIFF
--- a/care/sms/management/commands/send_weekly_email.py
+++ b/care/sms/management/commands/send_weekly_email.py
@@ -63,10 +63,17 @@ class Command(BaseCommand):
                 facility.last_message_date = now
                 facility.save()
         for key in settings.LIAISON_EMAIL_MAP.keys():
-            to_emails = settings.LIAISON_EMAIL_MAP[key]
-            non_cluser_facilities_txt = '\n'.join(non_cluser_facilities)
-            cluster_facilities_txt = '\n'.join(cluster_facilities)
-            message = LIAISON_WEEKLY_TPL['message'].format(non_cluser_facilities=non_cluser_facilities_txt, cluster_facilities=cluster_facilities_txt)
-            email_message = EmailMultiAlternatives(LIAISON_WEEKLY_TPL['subject'], message, settings.SENDGRID_FROM_EMAIL, [to_emails[0]], to_emails[1:], settings.LIAISON_EMAIL_MAP[key][0], reply_to=[settings.SENDGRID_REPLY_TO_EMAIL])
-            with mail.get_connection() as connection:
-                connection.send_messages([email_message])
+            if (len(non_cluser_facilities[key]) > 0) or (len(cluster_facilities[key]) > 0):
+                to_emails = settings.LIAISON_EMAIL_MAP[key]
+                if len(non_cluser_facilities[key]) > 0:
+                    non_cluser_facilities_txt = '\n'.join(non_cluser_facilities[key])
+                else:
+                    non_cluser_facilities_txt = 'None\n'
+                if len(cluster_facilities[key]) > 0:
+                    cluster_facilities_txt = '\n'.join(cluster_facilities[key])
+                else:
+                    cluster_facilities_txt = 'None\n'
+                message = LIAISON_WEEKLY_TPL['message'].format(non_cluser_facilities=non_cluser_facilities_txt, cluster_facilities=cluster_facilities_txt)
+                email_message = EmailMultiAlternatives(LIAISON_WEEKLY_TPL['subject'], message, settings.SENDGRID_FROM_EMAIL, [to_emails[0]], to_emails[1:], settings.LIAISON_EMAIL_MAP[key][0], reply_to=[settings.SENDGRID_REPLY_TO_EMAIL])
+                with mail.get_connection() as connection:
+                    connection.send_messages([email_message])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asgiref==3.2.5
 certifi==2019.11.28
 chardet==3.0.4
-Django==3.0.4
+Django==3.0.7
 djangorestframework==3.11.0
 gunicorn==20.0.4
 idna==2.9


### PR DESCRIPTION
fix sending wrong info for cluster/non-cluster text fields.
add some sanity checks (send 'None' if facility lists are empty, don't send email if both lists are empty)
